### PR TITLE
build: remove unused google-cloud-core version declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,11 +209,6 @@
       </dependency>
 
       <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-core-grpc</artifactId>
-        <version>${google.core.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>${protobuf.version}</version>


### PR DESCRIPTION
google-cloud-core is not a used dependency in this library. This will prevent renovate from trying to update it