### PR TITLE
docs(sample): adding native-image-sample for java-trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:24.3.0')
+implementation platform('com.google.cloud:libraries-bom:24.4.0')
 
 implementation 'com.google.cloud:google-cloud-trace'
 ```
@@ -98,6 +98,15 @@ use this Stackdriver Trace Client Library.
 
 
 
+
+
+## Samples
+
+Samples are in the [`samples/`](https://github.com/googleapis/java-trace/tree/main/samples) directory.
+
+| Sample                      | Source Code                       | Try it |
+| --------------------------- | --------------------------------- | ------ |
+| Trace Sample Application | [source code](https://github.com/googleapis/java-trace/blob/main/samples/native-image-sample/src/main/java/trace/TraceSampleApplication.java) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/java-trace&page=editor&open_in_editor=samples/native-image-sample/src/main/java/trace/TraceSampleApplication.java) |
 
 
 

--- a/samples/native-image-sample/README.md
+++ b/samples/native-image-sample/README.md
@@ -1,0 +1,42 @@
+# Cloud Trace Client Libraries with Native Image
+
+This application uses the Google Cloud [Trace Client Libraries](https://github.com/googleapis/java-trace) and can be compiled with Native Image.
+
+**Note:** In practice, the Trace Client Libraries are not used directly but through another tool, such as through the [OpenCensus Cloud Trace integration](https://cloud.google.com/trace/docs/setup/java) or through a framework like Spring via [Spring Cloud GCP Trace](https://github.com/spring-cloud/spring-cloud-gcp/blob/master/docs/src/main/asciidoc/trace.adoc).
+
+## Setup Instructions
+
+1. Follow the [GCP Project and Native Image Setup Instructions](../../README.md).
+
+2. Enable the [Cloud Trace APIs](https://console.cloud.google.com/apis/api/cloudtrace.googleapis.com/overview).
+
+## Run with Native Image Compilation
+
+Navigate to this directory in a new terminal.
+
+1. Compile the application using the Native Image Compiler. This step may take a few minutes.
+
+   ```
+   $ mvn package -P native -DskipTests
+   ```
+
+2. Run the application:
+
+   ```
+   $ ./target/native-image-sample
+   ```
+
+3. The application will generate a new trace and send the data to Cloud Trace where it will be viewable in the [Google Cloud Console Traces Viewer](https://console.cloud.google.com/traces/traces).
+
+   ```
+   Wait some time for the Trace to be populated.
+   Retrieved trace: 1be886734c6a4053adc4346b2b9040c5
+   It has the following spans: 
+   Span: nativeimage-trace-sample-test
+   ```
+
+4. Run the test in native-image mode:
+
+   ```
+   $ mvn test -P native
+   ```

--- a/samples/native-image-sample/README.md
+++ b/samples/native-image-sample/README.md
@@ -6,9 +6,42 @@ This application uses the Google Cloud [Trace Client Libraries](https://github.c
 
 ## Setup Instructions
 
-1. Follow the [GCP Project and Native Image Setup Instructions](../../README.md).
+You will need to follow these prerequisite steps in order to run these samples:
 
-2. Enable the [Cloud Trace APIs](https://console.cloud.google.com/apis/api/cloudtrace.googleapis.com/overview).
+1. If you have not already, [create a Google Cloud Platform Project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project).
+
+2. Install the [Google Cloud SDK](https://cloud.google.com/sdk/) which will allow you to run the sample with your project's credentials.
+
+   Once installed, log in with Application Default Credentials using the following command:
+
+    ```
+    gcloud auth application-default login
+    ```
+
+   **Note:** Authenticating with Application Default Credentials is convenient to use during development, but we recommend [alternate methods of authentication](https://cloud.google.com/docs/authentication/production) during production use.
+
+3. Install the GraalVM compiler.
+
+   You can follow the [official installation instructions](https://www.graalvm.org/docs/getting-started/#install-graalvm) from the GraalVM website.
+   After following the instructions, ensure that you install the Native Image extension installed by running:
+
+    ```
+    gu install native-image
+    ```
+
+   Once you finish following the instructions, verify that the default version of Java is set to the GraalVM version by running `java -version` in a terminal.
+
+   You will see something similar to the below output:
+
+    ```
+    $ java -version
+   
+    openjdk version "11.0.7" 2020-04-14
+    OpenJDK Runtime Environment GraalVM CE 20.1.0 (build 11.0.7+10-jvmci-20.1-b02)
+    OpenJDK 64-Bit Server VM GraalVM CE 20.1.0 (build 11.0.7+10-jvmci-20.1-b02, mixed mode, sharing)
+    ```
+
+4. Enable the [Cloud Trace APIs](https://console.cloud.google.com/apis/api/cloudtrace.googleapis.com/overview).
 
 ## Run with Native Image Compilation
 

--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.trace</groupId>
+  <artifactId>native-image-sample</artifactId>
+  <name>Native Image Sample</name>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <!-- Java 8 because the Kokoro Sample test uses that Java version -->
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>24.3.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-trace</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.1.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <!-- These plugins enable building the application to a JAR *not* using Native Image -->
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>trace.TraceSampleApplication</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>native</id>
+      <dependencies>
+        <dependency>
+          <!-- TODO: remove this when it's no longer needed -->
+          <groupId>com.google.cloud</groupId>
+          <artifactId>native-image-support</artifactId>
+          <version>0.12.0</version>
+        </dependency>
+        <dependency>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+          <version>5.8.2</version>
+        </dependency>
+        <dependency>
+          <groupId>org.graalvm.buildtools</groupId>
+          <artifactId>junit-platform-native</artifactId>
+          <version>0.9.9</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <!-- Must use older version of surefire plugin for native-image testing. -->
+            <version>2.22.2</version>
+            <configuration>
+              <includes>
+                <include>**/IT*</include>
+              </includes>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+            <version>0.9.9</version>
+            <extensions>true</extensions>
+            <configuration>
+              <mainClass>trace.TraceSampleApplication</mainClass>
+              <buildArgs>
+                <buildArg>--no-fallback</buildArg>
+                <buildArg>--no-server</buildArg>
+                <buildArg>--initialize-at-build-time</buildArg>
+                <buildArg>--features=com.google.cloud.nativeimage.features.ProtobufMessageFeature</buildArg>
+              </buildArgs>
+            </configuration>
+            <executions>
+              <execution>
+                <id>build-native</id>
+                <goals>
+                  <goal>build</goal>
+                  <goal>test</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+              <execution>
+                <id>test-native</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <phase>test</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -5,7 +5,9 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example.trace</groupId>
   <artifactId>native-image-sample</artifactId>
+  <version>0.1.0</version>
   <name>Native Image Sample</name>
+
 
   <!--
     The parent pom defines common style checks and testing strategies for our samples.
@@ -65,13 +67,35 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.2</version>
         <configuration>
           <archive>
             <manifest>
+              <addClasspath>true</addClasspath>
+              <classpathPrefix>dependency-jars/</classpathPrefix>
               <mainClass>trace.TraceSampleApplication</mainClass>
             </manifest>
           </archive>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>
+                ${project.build.directory}/dependency-jars/
+              </outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -146,7 +146,6 @@
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>--no-server</buildArg>
                 <buildArg>--initialize-at-build-time</buildArg>
-                <buildArg>--features=com.google.cloud.nativeimage.features.ProtobufMessageFeature</buildArg>
               </buildArgs>
             </configuration>
             <executions>

--- a/samples/native-image-sample/src/main/java/trace/TraceSampleApplication.java
+++ b/samples/native-image-sample/src/main/java/trace/TraceSampleApplication.java
@@ -29,14 +29,10 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.UUID;
 
-/**
- * Sample application demonstrating using the Google Trace client libraries.
- */
+/** Sample application demonstrating using the Google Trace client libraries. */
 public class TraceSampleApplication {
 
-  /**
-   * Runs basic methods in the Trace client libraries.
-   */
+  /** Runs basic methods in the Trace client libraries. */
   public static void main(String[] args) throws IOException, InterruptedException {
     String projectId = ServiceOptions.getDefaultProjectId();
     TraceServiceClient traceServiceClient = TraceServiceClient.create();
@@ -53,10 +49,7 @@ public class TraceSampleApplication {
     try {
       // This checks Cloud trace for the new trace that was just created.
       GetTraceRequest getTraceRequest =
-          GetTraceRequest.newBuilder()
-              .setProjectId(projectId)
-              .setTraceId(traceId)
-              .build();
+          GetTraceRequest.newBuilder().setProjectId(projectId).setTraceId(traceId).build();
 
       Trace trace = traceServiceClient.getTrace(getTraceRequest);
 
@@ -66,26 +59,30 @@ public class TraceSampleApplication {
         System.out.println("Span: " + span.getName());
       }
     } catch (NotFoundException e) {
-      System.out.println("We didn't find the trace: " + traceId + ". "
-          + "This is usually because we did not wait long enough. "
-          + "Please check https://console.cloud.google.com/traces/traces to "
-          + "find your trace in the traces viewer.");
+      System.out.println(
+          "We didn't find the trace: "
+              + traceId
+              + ". "
+              + "This is usually because we did not wait long enough. "
+              + "Please check https://console.cloud.google.com/traces/traces to "
+              + "find your trace in the traces viewer.");
     }
   }
 
   private static PatchTracesRequest createPatchTraceRequest(String traceId, String projectId) {
     long currentTime = Instant.now().toEpochMilli() / 1000;
 
-    Trace trace = Trace.newBuilder()
-        .setProjectId(projectId)
-        .setTraceId(traceId)
-        .addSpans(
-            TraceSpan.newBuilder()
-                .setSpanId(1)
-                .setName("nativeimage-trace-sample-test")
-                .setStartTime(Timestamp.newBuilder().setSeconds(currentTime - 5))
-                .setEndTime(Timestamp.newBuilder().setSeconds(currentTime)))
-        .build();
+    Trace trace =
+        Trace.newBuilder()
+            .setProjectId(projectId)
+            .setTraceId(traceId)
+            .addSpans(
+                TraceSpan.newBuilder()
+                    .setSpanId(1)
+                    .setName("nativeimage-trace-sample-test")
+                    .setStartTime(Timestamp.newBuilder().setSeconds(currentTime - 5))
+                    .setEndTime(Timestamp.newBuilder().setSeconds(currentTime)))
+            .build();
 
     PatchTracesRequest request =
         PatchTracesRequest.newBuilder()

--- a/samples/native-image-sample/src/main/java/trace/TraceSampleApplication.java
+++ b/samples/native-image-sample/src/main/java/trace/TraceSampleApplication.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020-2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package trace;
+
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.trace.v1.TraceServiceClient;
+import com.google.devtools.cloudtrace.v1.GetTraceRequest;
+import com.google.devtools.cloudtrace.v1.PatchTracesRequest;
+import com.google.devtools.cloudtrace.v1.Trace;
+import com.google.devtools.cloudtrace.v1.TraceSpan;
+import com.google.devtools.cloudtrace.v1.Traces;
+import com.google.protobuf.Timestamp;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Sample application demonstrating using the Google Trace client libraries.
+ */
+public class TraceSampleApplication {
+
+  /**
+   * Runs basic methods in the Trace client libraries.
+   */
+  public static void main(String[] args) throws IOException, InterruptedException {
+    String projectId = ServiceOptions.getDefaultProjectId();
+    TraceServiceClient traceServiceClient = TraceServiceClient.create();
+
+    // Create a trace in the current project.
+    String traceId = UUID.randomUUID().toString().replaceAll("-", "");
+    PatchTracesRequest createRequest = createPatchTraceRequest(traceId, projectId);
+    traceServiceClient.patchTraces(createRequest);
+
+    // Wait for the trace to be populated in Cloud Trace.
+    System.out.println("Wait some time for the Trace to be populated.");
+    Thread.sleep(3000);
+
+    try {
+      // This checks Cloud trace for the new trace that was just created.
+      GetTraceRequest getTraceRequest =
+          GetTraceRequest.newBuilder()
+              .setProjectId(projectId)
+              .setTraceId(traceId)
+              .build();
+
+      Trace trace = traceServiceClient.getTrace(getTraceRequest);
+
+      System.out.println("Retrieved trace: " + trace.getTraceId());
+      System.out.println("It has the following spans: ");
+      for (TraceSpan span : trace.getSpansList()) {
+        System.out.println("Span: " + span.getName());
+      }
+    } catch (NotFoundException e) {
+      System.out.println("We didn't find the trace: " + traceId + ". "
+          + "This is usually because we did not wait long enough. "
+          + "Please check https://console.cloud.google.com/traces/traces to "
+          + "find your trace in the traces viewer.");
+    }
+  }
+
+  private static PatchTracesRequest createPatchTraceRequest(String traceId, String projectId) {
+    long currentTime = Instant.now().toEpochMilli() / 1000;
+
+    Trace trace = Trace.newBuilder()
+        .setProjectId(projectId)
+        .setTraceId(traceId)
+        .addSpans(
+            TraceSpan.newBuilder()
+                .setSpanId(1)
+                .setName("nativeimage-trace-sample-test")
+                .setStartTime(Timestamp.newBuilder().setSeconds(currentTime - 5))
+                .setEndTime(Timestamp.newBuilder().setSeconds(currentTime)))
+        .build();
+
+    PatchTracesRequest request =
+        PatchTracesRequest.newBuilder()
+            .setProjectId(projectId)
+            .setTraces(Traces.newBuilder().addTraces(trace))
+            .build();
+
+    return request;
+  }
+}

--- a/samples/native-image-sample/src/test/java/trace/ITNativeImageTraceSample.java
+++ b/samples/native-image-sample/src/test/java/trace/ITNativeImageTraceSample.java
@@ -29,12 +29,12 @@ public class ITNativeImageTraceSample {
   @Before
   public void setUp() throws Exception {
     bout = new ByteArrayOutputStream();
-    System.setOut( new PrintStream(bout));
+    System.setOut(new PrintStream(bout));
   }
 
   @Test
   public void testRunSampleApplication() throws Exception {
-    TraceSampleApplication.main(new String[]{});
+    TraceSampleApplication.main(new String[] {});
     String output = bout.toString();
     assertThat(output).contains("Retrieved trace:");
     assertThat(output).contains("Span: nativeimage-trace-sample-test");

--- a/samples/native-image-sample/src/test/java/trace/ITNativeImageTraceSample.java
+++ b/samples/native-image-sample/src/test/java/trace/ITNativeImageTraceSample.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ITNativeImageTraceSample {
+  private ByteArrayOutputStream bout;
+
+  @Before
+  public void setUp() throws Exception {
+    bout = new ByteArrayOutputStream();
+    System.setOut( new PrintStream(bout));
+  }
+
+  @Test
+  public void testRunSampleApplication() throws Exception {
+    TraceSampleApplication.main(new String[]{});
+    String output = bout.toString();
+    assertThat(output).contains("Retrieved trace:");
+    assertThat(output).contains("Span: nativeimage-trace-sample-test");
+  }
+}

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -31,6 +31,7 @@
     <module>install-without-bom</module>
     <module>snapshot</module>
     <module>snippets</module>
+    <module>native-image-sample</module>
   </modules>
 
   <build>


### PR DESCRIPTION
Importing google-cloud-trace's sample to this repository. I confirmed it works as `samples/native-image-sample/README.md`.