### PR TITLE
docs(sample): clean up pom.xml of native image sample

### DIFF
--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -139,7 +139,6 @@
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>--no-server</buildArg>
-                <buildArg>--initialize-at-build-time</buildArg>
               </buildArgs>
             </configuration>
             <executions>
@@ -147,7 +146,6 @@
                 <id>build-native</id>
                 <goals>
                   <goal>build</goal>
-                  <goal>test</goal>
                 </goals>
                 <phase>package</phase>
               </execution>


### PR DESCRIPTION
Removing a couple of unused options. Thank you @ddobrin for pointing this out.