### PR TITLE
docs: README update for new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Java idiomatic client for [Stackdriver Trace][product-docs].
 
+:bus: In October 2022, this library has moved to
+[google-cloud-java/java-trace](
+https://github.com/googleapis/google-cloud-java/tree/main/java-trace).
+This repository will be archived in the future.
+Future releases will appear in the new repository (https://github.com/googleapis/google-cloud-java/releases).
+The Maven artifact coordinates (`com.google.cloud:google-cloud-trace`) remain the same.
+
 [![Maven][maven-version-image]][maven-version-link]
 ![Stability][stability-image]
 


### PR DESCRIPTION
docs: README update for new location

"GraalVM Native Image — Build failed" is fine.